### PR TITLE
update README.md , add partition size wrong notice when building mp

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ git clone --recurse-submodules <repository-url>
 ```
 
 Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
-  - # Name,   Type, SubType, Offset,  Size, Flags
+'''  - # Name,   Type, SubType, Offset,  Size, Flags
   - nvs,      data, nvs,     0x9000,  0x6000,
   - phy_init, data, phy,     0xf000,  0x1000,
   - factory,  app,  factory, 0x10000, 0x4F0000,
   - vfs,      data, fat,     0x500000, 0x500000,
 
   - Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
-
+'''
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ git clone --recurse-submodules <repository-url>
 
 Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
 ''
-# Name,   Type, SubType, Offset,  Size, Flags
-nvs,      data, nvs,     0x9000,  0x6000,
-phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 0x4F0000,
-vfs,      data, fat,     0x500000, 0x500000,
-
-Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
+# Name,   Type, SubType, Offset,  Size, Flags  
+nvs,      data, nvs,     0x9000,  0x6000,  
+phy_init, data, phy,     0xf000,  0x1000,  
+factory,  app,  factory, 0x10000, 0x4F0000,  
+vfs,      data, fat,     0x500000, 0x500000,  
 ''
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once you are sure it does, clone the repository with recursive submodules, this 
 git clone --recurse-submodules <repository-url>
 ```
 
-Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example partition table with 16MiB flash:
+Then you need to alter your partition table and add it into your sdkconfig.board, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project's manifest), following is an example partition table with 16MiB flash:
 ```
 # Name,   Type, SubType, Offset,  Size, Flags  
 nvs,      data, nvs,     0x9000,  0x6000,  

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Once you are sure it does, clone the repository with recursive submodules, this 
 git clone --recurse-submodules <repository-url>
 ```
 
-Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
+Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example partition table with 16MiB flash:
 ```
 # Name,   Type, SubType, Offset,  Size, Flags  
 nvs,      data, nvs,     0x9000,  0x6000,  
 phy_init, data, phy,     0xf000,  0x1000,  
-factory,  app,  factory, 0x10000, 0x4F0000,  
-vfs,      data, fat,     0x500000, 0x500000,  
+factory,  app,  factory, 0x10000, 0x2F0000,  
+vfs,      data, fat,     0x300000, 0x700000,  
 ```
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ git clone --recurse-submodules <repository-url>
 ```
 
 Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
-'''shell
-/# Name,   Type, SubType, Offset,  Size, Flags
+''
+# Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  app,  factory, 0x10000, 0x4F0000,
 vfs,      data, fat,     0x500000, 0x500000,
 
 Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
-'''
+''
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once you are sure it does, clone the repository with recursive submodules, this 
 git clone --recurse-submodules <repository-url>
 ```
 
-Then you need to alter your partition table and add it into your sdkconfig.board, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project's manifest), following is an example partition table with 16MiB flash:
+Then you need to alter your partition table and add it into your `sdkconfig.board`, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project's manifest), following is an example partition table with 16MiB flash:
 ```
 # Name,   Type, SubType, Offset,  Size, Flags  
 nvs,      data, nvs,     0x9000,  0x6000,  

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ git clone --recurse-submodules <repository-url>
 ```
 
 Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
-''
+```
 # Name,   Type, SubType, Offset,  Size, Flags  
 nvs,      data, nvs,     0x9000,  0x6000,  
 phy_init, data, phy,     0xf000,  0x1000,  
 factory,  app,  factory, 0x10000, 0x4F0000,  
 vfs,      data, fat,     0x500000, 0x500000,  
-''
+```
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Once you are sure it does, clone the repository with recursive submodules, this 
 git clone --recurse-submodules <repository-url>
 ```
 
+Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
+  - # Name,   Type, SubType, Offset,  Size, Flags
+  - nvs,      data, nvs,     0x9000,  0x6000,
+  - phy_init, data, phy,     0xf000,  0x1000,
+  - factory,  app,  factory, 0x10000, 0x4F0000,
+  - vfs,      data, fat,     0x500000, 0x500000,
+
+  - Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
+
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ git clone --recurse-submodules <repository-url>
 ```
 
 Then you need to create or alter your partition table, app partition (where binary micropython.bin exist) size need 0x260000 at least(depend on your project), following is an example:
-'''  - # Name,   Type, SubType, Offset,  Size, Flags
-  - nvs,      data, nvs,     0x9000,  0x6000,
-  - phy_init, data, phy,     0xf000,  0x1000,
-  - factory,  app,  factory, 0x10000, 0x4F0000,
-  - vfs,      data, fat,     0x500000, 0x500000,
+'''shell
+/# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 0x4F0000,
+vfs,      data, fat,     0x500000, 0x500000,
 
-  - Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
+Part 'factory' 0/0 @ 0x10000 size 0x1f0000 (overflow 0x62440)
 '''
 Compile adding the `USER_C_MODULES` parameter to the `make` command.
 


### PR DESCRIPTION
app partition in offical micropython partition table is too small, add a tip in README.md